### PR TITLE
few improvements to the report

### DIFF
--- a/lib/jasmine-xml2html-converter.js
+++ b/lib/jasmine-xml2html-converter.js
@@ -118,11 +118,11 @@ var generateTDTable = function (reportXml) {
   // Capture tessuite execution details   
   for (var i = 0; i < totalSuites; i++) {
     var suiteName = testSuites[i].attr.name;
-		var suiteTestErrors = parseInt(testSuites[i].attr.errors);
-		var suiteTotalTests = parseInt(testSuites[i].attr.tests);
-		var suiteTestSkips = parseInt(testSuites[i].attr.skipped);
-		var suiteTestFailures = parseInt(testSuites[i].attr.failures);
-		var suiteTestTime = parseFloat(testSuites[i].attr.time);
+		var suiteTestErrors = (testSuites[i].attr.errors == null) ? 0 : parseInt(testSuites[i].attr.errors);
+		var suiteTotalTests = (testSuites[i].attr.tests == null) ? 0 : parseInt(testSuites[i].attr.tests);
+		var suiteTestSkips = (testSuites[i].attr.skipped == null) ? 0 : parseInt(testSuites[i].attr.skipped);
+		var suiteTestFailures = (testSuites[i].attr.failures == null) ? 0 : parseInt(testSuites[i].attr.failures);
+		var suiteTestTime = (testSuites[i].attr.time == null) ? 0 : parseFloat(testSuites[i].attr.time);
 		var suitePassedTests = suiteTotalTests - suiteTestErrors - suiteTestSkips - suiteTestFailures;
 		totalTests += suiteTotalTests;
 		totalFailures += suiteTestFailures;
@@ -161,7 +161,9 @@ var generateTDTable = function (reportXml) {
 	}
   testExecInfo['testStartedOn'] = testStartedOn;
   testExecInfo['totalTests'] = totalTests;
-  testExecInfo['passRate'] = ((totalTests - totalFailures - totalSkips) / totalTests).toFixed(3);
+  testExecInfo['totalFailures'] = totalFailures;
+  testExecInfo['totalPassed'] = (totalTests - totalFailures - totalSkips);
+  testExecInfo['passRate'] = ( testExecInfo['totalPassed'] / totalTests).toFixed(3);
   testExecInfo['execTime'] = totalExecTime.toFixed(3);
   return testDetailsTable;
 };
@@ -180,6 +182,8 @@ var generateTSTable = function(testConfig) {
   }
   testSummaryTable += '<li><b>Test Start:</b> ' + testExecInfo['testStartedOn'] + '</li>';
   testSummaryTable += '<li><b>Total Tests:</b> ' + testExecInfo['totalTests'] + '</li>';
+  testSummaryTable += '<li><b>Total Pass:</b> ' + testExecInfo['totalPassed'] + '</li>';
+  testSummaryTable += '<li><b>Total Failed:</b> ' + testExecInfo['totalFailures'] + '</li>';
   testSummaryTable += '<li><b>Pass Rate:</b> ' + testExecInfo['passRate'] * 100 + '% </li>';
   testSummaryTable += '<li><b>Execution Duration:</b> ' + testExecInfo['execTime'] + ' Secs</li>';
   testSummaryTable += '</ul></div></td><td id="td-ts-table" rowspan=2>';


### PR DESCRIPTION
1. when the xml does not contain pass, fail or skipped "testSuites[i].attr.errors" becomes null and that effects the parsing hence added a checkpoint to set 0 if the attr is null and parse otherwise.
2. Added total pass count and total fail count to the report summery by adding them to "testExecInfo". The reason to add this is otherwise the report viewer has to do a calculation to come up with these values

please review and add the changes
